### PR TITLE
gitignore - Excluded Rider link from plugins and removed Bridge plugin dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ DerivedDataCache/*
 # Rider stuff
 .idea/
 *.user
+Plugins/Developer/RiderLink*

--- a/MassSample.uproject
+++ b/MassSample.uproject
@@ -33,15 +33,6 @@
 		{
 			"Name": "MassCrowd",
 			"Enabled": true
-		},
-		{
-			"Name": "Bridge",
-			"Enabled": true,
-			"SupportedTargetPlatforms": [
-				"Win64",
-				"Mac",
-				"Linux"
-			]
 		}
 	]
 }


### PR DESCRIPTION
Small update to enable excluding Rider plugin from project files. In recent version until Rider can be again installed in engine, this is needed.