### PR TITLE
Unit Formations Example

### DIFF
--- a/Plugins/RTSFormations/Content/DA_AgentFormation.uasset
+++ b/Plugins/RTSFormations/Content/DA_AgentFormation.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25b9bef364eb89ab5f1afc55d48473f632ed62f6dfd396214d24489c128fae28
+size 3897

--- a/Plugins/RTSFormations/Content/DA_AgentFormation.uasset
+++ b/Plugins/RTSFormations/Content/DA_AgentFormation.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25b9bef364eb89ab5f1afc55d48473f632ed62f6dfd396214d24489c128fae28
-size 3897
+oid sha256:e09aeb6d360f2f876a8db14199a67c0c2c326abc3639ca6dacdb7d867c729095
+size 5886

--- a/Plugins/RTSFormations/Content/RTSFormationsExample.umap
+++ b/Plugins/RTSFormations/Content/RTSFormationsExample.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13e8cbdf14a10979f5ffbfae0622ac95f1b54bc0c81546434399e5a405ca4bfd
-size 36392
+oid sha256:027894da6515631e5c3356ec6cab86bf95505056734fdedf77b3107af446718a
+size 39665

--- a/Plugins/RTSFormations/Content/RTSFormationsExample.umap
+++ b/Plugins/RTSFormations/Content/RTSFormationsExample.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13e8cbdf14a10979f5ffbfae0622ac95f1b54bc0c81546434399e5a405ca4bfd
+size 36392

--- a/Plugins/RTSFormations/RTSFormations.uplugin
+++ b/Plugins/RTSFormations/RTSFormations.uplugin
@@ -20,5 +20,27 @@
 			"Type": "Runtime",
 			"LoadingPhase": "Default"
 		}
+	],
+	"Plugins": [
+		{
+			"Name": "MassGameplay",
+			"Enabled": true
+		},
+		{
+			"Name": "MassEntity",
+			"Enabled": true
+		},
+		{
+			"Name": "MassGameplay",
+			"Enabled": true
+		},
+		{
+			"Name": "MassAI",
+			"Enabled": true
+		},
+		{
+			"Name": "StructUtils",
+			"Enabled": true
+		}
 	]
 }

--- a/Plugins/RTSFormations/RTSFormations.uplugin
+++ b/Plugins/RTSFormations/RTSFormations.uplugin
@@ -1,0 +1,24 @@
+{
+	"FileVersion": 3,
+	"Version": 1,
+	"VersionName": "1.0",
+	"FriendlyName": "RTSFormations",
+	"Description": "",
+	"Category": "Other",
+	"CreatedBy": "JiRath",
+	"CreatedByURL": "",
+	"DocsURL": "",
+	"MarketplaceURL": "",
+	"SupportURL": "",
+	"CanContainContent": true,
+	"IsBetaVersion": true,
+	"IsExperimentalVersion": false,
+	"Installed": false,
+	"Modules": [
+		{
+			"Name": "RTSFormations",
+			"Type": "Runtime",
+			"LoadingPhase": "Default"
+		}
+	]
+}

--- a/Plugins/RTSFormations/Resources/Icon128.png
+++ b/Plugins/RTSFormations/Resources/Icon128.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7239efaeefbd82de33ebe18518e50de075ea4188a468a9e4991396433d2275f
+size 12699

--- a/Plugins/RTSFormations/Source/RTSFormations/Private/RTSAgentTraits.cpp
+++ b/Plugins/RTSFormations/Source/RTSFormations/Private/RTSAgentTraits.cpp
@@ -76,8 +76,7 @@ void URTSFormationInitializer::Execute(UMassEntitySubsystem& EntitySubsystem, FM
 						MoveTarget.Center = FVector(w*BufferDistance,l*BufferDistance,0.f);
 						MoveTarget.Forward = (Transform.GetLocation() - MoveTarget.Center).GetSafeNormal();
 						MoveTarget.DistanceToGoal = (Transform.GetLocation() - MoveTarget.Center).Length();
-						//MoveTarget.DesiredSpeed = FMassInt16Real(200.f);
-						UE_LOG(LogTemp, Error, TEXT("MOVE TARGET: %s"), *(MoveTarget.Center.ToString()));
+						MoveTarget.SlackRadius = 50.f;
 					}
 				}
 			}
@@ -104,6 +103,11 @@ void URTSAgentMovement::Execute(UMassEntitySubsystem& EntitySubsystem, FMassExec
 			
 			MoveTarget.DistanceToGoal = (MoveTarget.Center - Transform.GetLocation()).Length();
 			MoveTarget.Forward = (MoveTarget.Center - Transform.GetLocation()).GetSafeNormal();
+
+			if (MoveTarget.DistanceToGoal <= MoveTarget.SlackRadius)
+			{
+				MoveTarget.CreateNewAction(EMassMovementAction::Stand, *GetWorld());
+			}
 		}
 	});
 }

--- a/Plugins/RTSFormations/Source/RTSFormations/Private/RTSAgentTraits.cpp
+++ b/Plugins/RTSFormations/Source/RTSFormations/Private/RTSAgentTraits.cpp
@@ -9,7 +9,15 @@
 
 void URTSFormationAgentTrait::BuildTemplate(FMassEntityTemplateBuildContext& BuildContext, UWorld& World) const
 {
+	UMassEntitySubsystem* EntitySubsystem = UWorld::GetSubsystem<UMassEntitySubsystem>(&World);
+	check(EntitySubsystem);
+	
 	BuildContext.AddFragment<FRTSFormationAgent>();
+	
+	FRTSFormationSettings MyFragment;
+	uint32 MySharedFragmentHash = UE::StructUtils::GetStructCrc32(FConstStructView::Make(MyFragment));
+	FSharedStruct MySharedFragment = EntitySubsystem->GetOrCreateSharedFragment<FRTSFormationSettings>(MySharedFragmentHash, MyFragment);
+	BuildContext.AddSharedFragment(MySharedFragment);
 }
 
 URTSFormationInitializer::URTSFormationInitializer()
@@ -25,6 +33,7 @@ void URTSFormationInitializer::ConfigureQueries()
 	MoveEntityQuery.AddRequirement<FRTSFormationAgent>(EMassFragmentAccess::ReadOnly);
 	MoveEntityQuery.AddRequirement<FMassMoveTargetFragment>(EMassFragmentAccess::ReadWrite);
 	MoveEntityQuery.AddRequirement<FTransformFragment>(EMassFragmentAccess::ReadOnly);
+	MoveEntityQuery.AddSharedRequirement<FRTSFormationSettings>(EMassFragmentAccess::ReadOnly);
 }
 
 void URTSFormationInitializer::Initialize(UObject& Owner)
@@ -34,11 +43,12 @@ void URTSFormationInitializer::Initialize(UObject& Owner)
 
 void URTSFormationInitializer::Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context)
 {
-	UE_LOG(LogTemp, Error, TEXT("RAN EXECUTE"));
 	// First query is to give all units an appropriate unit index.
 	// @todo The unit index is given 'randomly' regardless of distance to closest formation position.
+	// Ideas: When a unit is already assigned an index, we shouldnt have to recalculate it unless a unit was destroyed and the index destroyed is less than
+	// the units index - pretty much like an array, would it be inefficient though?
 	int UnitIndex = 0;
-	EntityQuery.ForEachEntityChunk(EntitySubsystem, Context, [this, &UnitIndex](FMassExecutionContext& Context)
+	EntityQuery.ParallelForEachEntityChunk(EntitySubsystem, Context, [this, &UnitIndex](FMassExecutionContext& Context)
 	{
 		TArrayView<FRTSFormationAgent> RTSFormationAgents = Context.GetMutableFragmentView<FRTSFormationAgent>();
 		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
@@ -49,37 +59,43 @@ void URTSFormationInitializer::Execute(UMassEntitySubsystem& EntitySubsystem, FM
 		}
 	});
 
+	// Square formations have equal sides, so sqrt num units to get side length
+	//const float UnitFloat = UnitIndex;
+	//const int SideLength = FMath::CeilToInt(FMath::Sqrt(UnitFloat));
+			
+	//const int BufferDistance = 200.f; // Distance between each unit
+
+	// Query to calculate move target for entities based on unit index
 	MoveEntityQuery.ParallelForEachEntityChunk(EntitySubsystem, Context, [this, &UnitIndex](FMassExecutionContext& Context)
 	{
 		TConstArrayView<FRTSFormationAgent> RTSFormationAgents = Context.GetFragmentView<FRTSFormationAgent>();
 		TArrayView<FMassMoveTargetFragment> MoveTargetFragments = Context.GetMutableFragmentView<FMassMoveTargetFragment>();
 		TConstArrayView<FTransformFragment> TransformFragments = Context.GetFragmentView<FTransformFragment>();
+		const FRTSFormationSettings& RTSFormationSettings = Context.GetSharedFragment<FRTSFormationSettings>();
+
+		const int Whole = RTSFormationSettings.UnitRatioX + RTSFormationSettings.UnitRatioY;
+		const int SideLengthX = RTSFormationSettings.UnitRatioX / Whole * UnitIndex;
+		const int SideLengthY = RTSFormationSettings.UnitRatioY / Whole * UnitIndex;
+		
 		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
 		{
 			const FRTSFormationAgent& RTSFormationAgent = RTSFormationAgents[EntityIndex];
 			FMassMoveTargetFragment& MoveTarget = MoveTargetFragments[EntityIndex];
 			const FTransform& Transform = TransformFragments[EntityIndex].GetTransform();
 
-			const float UnitFloat = UnitIndex;
-			const int SideLength = FMath::CeilToInt(FMath::Sqrt(UnitFloat));
-			const int BufferDistance = 200.f;
-			for(int w = 0;w<SideLength;++w)
-			{
-				for(int l = 0;l<SideLength;++l)
-				{
-					// This can be significantly optimized by calculating x/y once rather than looping
-					// My small brain just cant comprehend it right now
-					int CurrentIndex = w*SideLength+l;
-					if (CurrentIndex == RTSFormationAgent.UnitIndex)
-					{
-						MoveTarget.CreateNewAction(EMassMovementAction::Move, *GetWorld());
-						MoveTarget.Center = FVector(w*BufferDistance,l*BufferDistance,0.f);
-						MoveTarget.Forward = (Transform.GetLocation() - MoveTarget.Center).GetSafeNormal();
-						MoveTarget.DistanceToGoal = (Transform.GetLocation() - MoveTarget.Center).Length();
-						MoveTarget.SlackRadius = 50.f;
-					}
-				}
-			}
+			// Convert UnitIndex to X/Y coords
+			int w = RTSFormationAgent.UnitIndex / SideLengthX;
+			int l = RTSFormationAgent.UnitIndex % SideLengthY;
+
+			// We want the formation to be 'centered' so we need to create an offset
+			FVector CenterOffset((SideLengthX/2) * RTSFormationSettings.BufferDistance, (SideLengthY/2) * RTSFormationSettings.BufferDistance, 0.f);
+
+			// Create movement action
+			MoveTarget.CreateNewAction(EMassMovementAction::Move, *GetWorld());
+			MoveTarget.Center = FVector(w*RTSFormationSettings.BufferDistance-CenterOffset.X,l*RTSFormationSettings.BufferDistance-CenterOffset.Y,0.f);
+			MoveTarget.Forward = (Transform.GetLocation() - MoveTarget.Center).GetSafeNormal();
+			MoveTarget.DistanceToGoal = (Transform.GetLocation() - MoveTarget.Center).Length();
+			MoveTarget.SlackRadius = 25.f;
 		}
 	});
 }
@@ -104,6 +120,7 @@ void URTSAgentMovement::Execute(UMassEntitySubsystem& EntitySubsystem, FMassExec
 			MoveTarget.DistanceToGoal = (MoveTarget.Center - Transform.GetLocation()).Length();
 			MoveTarget.Forward = (MoveTarget.Center - Transform.GetLocation()).GetSafeNormal();
 
+			// Once we are close enough to our goal, create stand action
 			if (MoveTarget.DistanceToGoal <= MoveTarget.SlackRadius)
 			{
 				MoveTarget.CreateNewAction(EMassMovementAction::Stand, *GetWorld());

--- a/Plugins/RTSFormations/Source/RTSFormations/Private/RTSAgentTraits.cpp
+++ b/Plugins/RTSFormations/Source/RTSFormations/Private/RTSAgentTraits.cpp
@@ -3,9 +3,9 @@
 
 #include "RTSAgentTraits.h"
 
-#include "MassCommonFragments.h"
 #include "MassEntityTemplateRegistry.h"
 #include "MassNavigationFragments.h"
+#include "MassObserverRegistry.h"
 
 void URTSFormationAgentTrait::BuildTemplate(FMassEntityTemplateBuildContext& BuildContext, UWorld& World) const
 {
@@ -14,117 +14,7 @@ void URTSFormationAgentTrait::BuildTemplate(FMassEntityTemplateBuildContext& Bui
 	
 	BuildContext.AddFragment<FRTSFormationAgent>();
 	
-	FRTSFormationSettings MyFragment;
-	uint32 MySharedFragmentHash = UE::StructUtils::GetStructCrc32(FConstStructView::Make(MyFragment));
-	FSharedStruct MySharedFragment = EntitySubsystem->GetOrCreateSharedFragment<FRTSFormationSettings>(MySharedFragmentHash, MyFragment);
+	uint32 MySharedFragmentHash = UE::StructUtils::GetStructCrc32(FConstStructView::Make(FormationSettings));
+	FSharedStruct MySharedFragment = EntitySubsystem->GetOrCreateSharedFragment<FRTSFormationSettings>(MySharedFragmentHash, FormationSettings);
 	BuildContext.AddSharedFragment(MySharedFragment);
-}
-
-URTSFormationInitializer::URTSFormationInitializer()
-{
-	ObservedType = FRTSFormationAgent::StaticStruct();
-	Operation = EMassObservedOperation::Add;
-}
-
-void URTSFormationInitializer::ConfigureQueries()
-{
-	EntityQuery.AddRequirement<FRTSFormationAgent>(EMassFragmentAccess::ReadWrite);
-
-	MoveEntityQuery.AddRequirement<FRTSFormationAgent>(EMassFragmentAccess::ReadOnly);
-	MoveEntityQuery.AddRequirement<FMassMoveTargetFragment>(EMassFragmentAccess::ReadWrite);
-	MoveEntityQuery.AddRequirement<FTransformFragment>(EMassFragmentAccess::ReadOnly);
-	MoveEntityQuery.AddSharedRequirement<FRTSFormationSettings>(EMassFragmentAccess::ReadOnly);
-}
-
-void URTSFormationInitializer::Initialize(UObject& Owner)
-{
-	Super::Initialize(Owner);
-}
-
-void URTSFormationInitializer::Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context)
-{
-	// First query is to give all units an appropriate unit index.
-	// @todo The unit index is given 'randomly' regardless of distance to closest formation position.
-	// Ideas: When a unit is already assigned an index, we shouldnt have to recalculate it unless a unit was destroyed and the index destroyed is less than
-	// the units index - pretty much like an array, would it be inefficient though?
-	int UnitIndex = 0;
-	EntityQuery.ParallelForEachEntityChunk(EntitySubsystem, Context, [this, &UnitIndex](FMassExecutionContext& Context)
-	{
-		TArrayView<FRTSFormationAgent> RTSFormationAgents = Context.GetMutableFragmentView<FRTSFormationAgent>();
-		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
-		{
-			FRTSFormationAgent& RTSFormationAgent = RTSFormationAgents[EntityIndex];
-			RTSFormationAgent.UnitIndex = UnitIndex;
-			UnitIndex++;
-		}
-	});
-
-	// Square formations have equal sides, so sqrt num units to get side length
-	//const float UnitFloat = UnitIndex;
-	//const int SideLength = FMath::CeilToInt(FMath::Sqrt(UnitFloat));
-			
-	//const int BufferDistance = 200.f; // Distance between each unit
-
-	// Query to calculate move target for entities based on unit index
-	MoveEntityQuery.ParallelForEachEntityChunk(EntitySubsystem, Context, [this, &UnitIndex](FMassExecutionContext& Context)
-	{
-		TConstArrayView<FRTSFormationAgent> RTSFormationAgents = Context.GetFragmentView<FRTSFormationAgent>();
-		TArrayView<FMassMoveTargetFragment> MoveTargetFragments = Context.GetMutableFragmentView<FMassMoveTargetFragment>();
-		TConstArrayView<FTransformFragment> TransformFragments = Context.GetFragmentView<FTransformFragment>();
-		const FRTSFormationSettings& RTSFormationSettings = Context.GetSharedFragment<FRTSFormationSettings>();
-
-		const int Whole = RTSFormationSettings.UnitRatioX + RTSFormationSettings.UnitRatioY;
-		const int SideLengthX = RTSFormationSettings.UnitRatioX / Whole * UnitIndex;
-		const int SideLengthY = RTSFormationSettings.UnitRatioY / Whole * UnitIndex;
-		
-		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
-		{
-			const FRTSFormationAgent& RTSFormationAgent = RTSFormationAgents[EntityIndex];
-			FMassMoveTargetFragment& MoveTarget = MoveTargetFragments[EntityIndex];
-			const FTransform& Transform = TransformFragments[EntityIndex].GetTransform();
-
-			// Convert UnitIndex to X/Y coords
-			int w = RTSFormationAgent.UnitIndex / SideLengthX;
-			int l = RTSFormationAgent.UnitIndex % SideLengthY;
-
-			// We want the formation to be 'centered' so we need to create an offset
-			FVector CenterOffset((SideLengthX/2) * RTSFormationSettings.BufferDistance, (SideLengthY/2) * RTSFormationSettings.BufferDistance, 0.f);
-
-			// Create movement action
-			MoveTarget.CreateNewAction(EMassMovementAction::Move, *GetWorld());
-			MoveTarget.Center = FVector(w*RTSFormationSettings.BufferDistance-CenterOffset.X,l*RTSFormationSettings.BufferDistance-CenterOffset.Y,0.f);
-			MoveTarget.Forward = (Transform.GetLocation() - MoveTarget.Center).GetSafeNormal();
-			MoveTarget.DistanceToGoal = (Transform.GetLocation() - MoveTarget.Center).Length();
-			MoveTarget.SlackRadius = 25.f;
-		}
-	});
-}
-
-void URTSAgentMovement::ConfigureQueries()
-{
-	EntityQuery.AddRequirement<FMassMoveTargetFragment>(EMassFragmentAccess::ReadWrite);
-	EntityQuery.AddRequirement<FTransformFragment>(EMassFragmentAccess::ReadOnly);
-}
-
-void URTSAgentMovement::Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context)
-{
-	EntityQuery.ParallelForEachEntityChunk(EntitySubsystem, Context, [this](FMassExecutionContext& Context)
-	{
-		TArrayView<FMassMoveTargetFragment> MoveTargetFragments = Context.GetMutableFragmentView<FMassMoveTargetFragment>();
-		TConstArrayView<FTransformFragment> TransformFragments = Context.GetFragmentView<FTransformFragment>();
-		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
-		{
-			FMassMoveTargetFragment& MoveTarget = MoveTargetFragments[EntityIndex];
-			const FTransform& Transform = TransformFragments[EntityIndex].GetTransform();
-			
-			MoveTarget.DistanceToGoal = (MoveTarget.Center - Transform.GetLocation()).Length();
-			MoveTarget.Forward = (MoveTarget.Center - Transform.GetLocation()).GetSafeNormal();
-
-			// Once we are close enough to our goal, create stand action
-			if (MoveTarget.DistanceToGoal <= MoveTarget.SlackRadius)
-			{
-				MoveTarget.CreateNewAction(EMassMovementAction::Stand, *GetWorld());
-			}
-		}
-	});
 }

--- a/Plugins/RTSFormations/Source/RTSFormations/Private/RTSAgentTraits.cpp
+++ b/Plugins/RTSFormations/Source/RTSFormations/Private/RTSAgentTraits.cpp
@@ -1,0 +1,109 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RTSAgentTraits.h"
+
+#include "MassCommonFragments.h"
+#include "MassEntityTemplateRegistry.h"
+#include "MassNavigationFragments.h"
+
+void URTSFormationAgentTrait::BuildTemplate(FMassEntityTemplateBuildContext& BuildContext, UWorld& World) const
+{
+	BuildContext.AddFragment<FRTSFormationAgent>();
+}
+
+URTSFormationInitializer::URTSFormationInitializer()
+{
+	ObservedType = FRTSFormationAgent::StaticStruct();
+	Operation = EMassObservedOperation::Add;
+}
+
+void URTSFormationInitializer::ConfigureQueries()
+{
+	EntityQuery.AddRequirement<FRTSFormationAgent>(EMassFragmentAccess::ReadWrite);
+
+	MoveEntityQuery.AddRequirement<FRTSFormationAgent>(EMassFragmentAccess::ReadOnly);
+	MoveEntityQuery.AddRequirement<FMassMoveTargetFragment>(EMassFragmentAccess::ReadWrite);
+	MoveEntityQuery.AddRequirement<FTransformFragment>(EMassFragmentAccess::ReadOnly);
+}
+
+void URTSFormationInitializer::Initialize(UObject& Owner)
+{
+	Super::Initialize(Owner);
+}
+
+void URTSFormationInitializer::Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context)
+{
+	UE_LOG(LogTemp, Error, TEXT("RAN EXECUTE"));
+	// First query is to give all units an appropriate unit index.
+	// @todo The unit index is given 'randomly' regardless of distance to closest formation position.
+	int UnitIndex = 0;
+	EntityQuery.ForEachEntityChunk(EntitySubsystem, Context, [this, &UnitIndex](FMassExecutionContext& Context)
+	{
+		TArrayView<FRTSFormationAgent> RTSFormationAgents = Context.GetMutableFragmentView<FRTSFormationAgent>();
+		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
+		{
+			FRTSFormationAgent& RTSFormationAgent = RTSFormationAgents[EntityIndex];
+			RTSFormationAgent.UnitIndex = UnitIndex;
+			UnitIndex++;
+		}
+	});
+
+	MoveEntityQuery.ParallelForEachEntityChunk(EntitySubsystem, Context, [this, &UnitIndex](FMassExecutionContext& Context)
+	{
+		TConstArrayView<FRTSFormationAgent> RTSFormationAgents = Context.GetFragmentView<FRTSFormationAgent>();
+		TArrayView<FMassMoveTargetFragment> MoveTargetFragments = Context.GetMutableFragmentView<FMassMoveTargetFragment>();
+		TConstArrayView<FTransformFragment> TransformFragments = Context.GetFragmentView<FTransformFragment>();
+		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
+		{
+			const FRTSFormationAgent& RTSFormationAgent = RTSFormationAgents[EntityIndex];
+			FMassMoveTargetFragment& MoveTarget = MoveTargetFragments[EntityIndex];
+			const FTransform& Transform = TransformFragments[EntityIndex].GetTransform();
+
+			const float UnitFloat = UnitIndex;
+			const int SideLength = FMath::CeilToInt(FMath::Sqrt(UnitFloat));
+			const int BufferDistance = 200.f;
+			for(int w = 0;w<SideLength;++w)
+			{
+				for(int l = 0;l<SideLength;++l)
+				{
+					// This can be significantly optimized by calculating x/y once rather than looping
+					// My small brain just cant comprehend it right now
+					int CurrentIndex = w*SideLength+l;
+					if (CurrentIndex == RTSFormationAgent.UnitIndex)
+					{
+						MoveTarget.CreateNewAction(EMassMovementAction::Move, *GetWorld());
+						MoveTarget.Center = FVector(w*BufferDistance,l*BufferDistance,0.f);
+						MoveTarget.Forward = (Transform.GetLocation() - MoveTarget.Center).GetSafeNormal();
+						MoveTarget.DistanceToGoal = (Transform.GetLocation() - MoveTarget.Center).Length();
+						//MoveTarget.DesiredSpeed = FMassInt16Real(200.f);
+						UE_LOG(LogTemp, Error, TEXT("MOVE TARGET: %s"), *(MoveTarget.Center.ToString()));
+					}
+				}
+			}
+		}
+	});
+}
+
+void URTSAgentMovement::ConfigureQueries()
+{
+	EntityQuery.AddRequirement<FMassMoveTargetFragment>(EMassFragmentAccess::ReadWrite);
+	EntityQuery.AddRequirement<FTransformFragment>(EMassFragmentAccess::ReadOnly);
+}
+
+void URTSAgentMovement::Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context)
+{
+	EntityQuery.ParallelForEachEntityChunk(EntitySubsystem, Context, [this](FMassExecutionContext& Context)
+	{
+		TArrayView<FMassMoveTargetFragment> MoveTargetFragments = Context.GetMutableFragmentView<FMassMoveTargetFragment>();
+		TConstArrayView<FTransformFragment> TransformFragments = Context.GetFragmentView<FTransformFragment>();
+		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
+		{
+			FMassMoveTargetFragment& MoveTarget = MoveTargetFragments[EntityIndex];
+			const FTransform& Transform = TransformFragments[EntityIndex].GetTransform();
+			
+			MoveTarget.DistanceToGoal = (MoveTarget.Center - Transform.GetLocation()).Length();
+			MoveTarget.Forward = (MoveTarget.Center - Transform.GetLocation()).GetSafeNormal();
+		}
+	});
+}

--- a/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormationProcessors.cpp
+++ b/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormationProcessors.cpp
@@ -1,0 +1,166 @@
+﻿#include "RTSFormationProcessors.h"
+
+#include "MassCommonFragments.h"
+#include "MassMovementFragments.h"
+#include "MassNavigationFragments.h"
+#include "MassNavigationTypes.h"
+#include "MassObserverRegistry.h"
+#include "MassSignalSubsystem.h"
+#include "RTSAgentTraits.h"
+#include "RTSFormationSubsystem.h"
+
+URTSFormationInitializer::URTSFormationInitializer()
+{
+	ObservedType = FRTSFormationAgent::StaticStruct();
+	Operation = EMassObservedOperation::Add;
+}
+
+void URTSFormationInitializer::ConfigureQueries()
+{
+	EntityQuery.AddRequirement<FRTSFormationAgent>(EMassFragmentAccess::ReadWrite);
+	EntityQuery.AddSharedRequirement<FRTSFormationSettings>(EMassFragmentAccess::ReadWrite);
+
+	DestroyQuery.AddRequirement<FRTSFormationAgent>(EMassFragmentAccess::None, EMassFragmentPresence::None);
+	DestroyQuery.AddSharedRequirement<FRTSFormationSettings>(EMassFragmentAccess::ReadWrite);
+}
+
+void URTSFormationInitializer::Initialize(UObject& Owner)
+{
+	Super::Initialize(Owner);
+
+	SignalSubsystem = UWorld::GetSubsystem<UMassSignalSubsystem>(Owner.GetWorld());
+	FormationSubsystem = UWorld::GetSubsystem<URTSFormationSubsystem>(Owner.GetWorld());
+}
+
+void URTSFormationInitializer::Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context)
+{
+	// First query is to give all units an appropriate unit index.
+	// @todo The unit index is given 'randomly' regardless of distance to closest formation position.
+	// Ideas: When a unit is already assigned an index, we shouldnt have to recalculate it unless a unit was destroyed and the index destroyed is less than
+	// the units index - pretty much like an array, would it be inefficient though?
+	// Another issue is that the center offset changes when enough units are spawned, causing the positions of the other units to be off
+
+	// Since I really want this example to be straightforward, Im going to streamline adding/remove entities so that the formation gets recalculated
+	int UnitIndex = 0;
+	EntityQuery.ParallelForEachEntityChunk(EntitySubsystem, Context, [this, &UnitIndex](FMassExecutionContext& Context)
+	{
+		TArrayView<FRTSFormationAgent> RTSFormationAgents = Context.GetMutableFragmentView<FRTSFormationAgent>();
+		FRTSFormationSettings& RTSFormationSettings = Context.GetMutableSharedFragment<FRTSFormationSettings>();
+		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
+		{
+			FRTSFormationAgent& RTSFormationAgent = RTSFormationAgents[EntityIndex];
+			RTSFormationAgent.UnitIndex = UnitIndex;
+			FormationSubsystem->Units.Emplace(Context.GetEntity(EntityIndex));
+			SignalSubsystem->SignalEntities(FormationUpdated, FormationSubsystem->Units);
+		}
+	});
+
+	DestroyQuery.ParallelForEachEntityChunk(EntitySubsystem, Context, [this, &UnitIndex](FMassExecutionContext& Context)
+	{
+		FRTSFormationSettings& RTSFormationSettings = Context.GetMutableSharedFragment<FRTSFormationSettings>();
+		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
+		{
+			FormationSubsystem->Units.Remove(Context.GetEntity(EntityIndex));
+			SignalSubsystem->SignalEntities(FormationUpdated, FormationSubsystem->Units);
+		}
+	});
+}
+
+void URTSFormationInitializer::Register()
+{
+	Super::Register();
+
+	// Register removal of entity
+	UMassObserverRegistry::GetMutable().RegisterObserver(*ObservedType, EMassObservedOperation::Remove, GetClass());
+}
+
+void URTSAgentMovement::ConfigureQueries()
+{
+	EntityQuery.AddRequirement<FMassMoveTargetFragment>(EMassFragmentAccess::ReadWrite);
+	EntityQuery.AddRequirement<FTransformFragment>(EMassFragmentAccess::ReadOnly);
+	EntityQuery.AddSharedRequirement<FRTSFormationSettings>(EMassFragmentAccess::ReadWrite);
+	EntityQuery.AddRequirement<FMassVelocityFragment>(EMassFragmentAccess::ReadWrite);
+}
+
+void URTSAgentMovement::Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context)
+{
+	EntityQuery.ParallelForEachEntityChunk(EntitySubsystem, Context, [this](FMassExecutionContext& Context)
+	{
+		TArrayView<FMassMoveTargetFragment> MoveTargetFragments = Context.GetMutableFragmentView<FMassMoveTargetFragment>();
+		TConstArrayView<FTransformFragment> TransformFragments = Context.GetFragmentView<FTransformFragment>();
+		FRTSFormationSettings& FormationSettings = Context.GetMutableSharedFragment<FRTSFormationSettings>();
+		TArrayView<FMassVelocityFragment> VelocityFragments = Context.GetMutableFragmentView<FMassVelocityFragment>();
+		
+		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
+		{
+			FMassMoveTargetFragment& MoveTarget = MoveTargetFragments[EntityIndex];
+			const FTransform& Transform = TransformFragments[EntityIndex].GetTransform();
+			FVector& Velocity = VelocityFragments[EntityIndex].Value;
+
+			// Update move target values
+			MoveTarget.DistanceToGoal = (MoveTarget.Center - Transform.GetLocation()).Length();
+			MoveTarget.Forward = (MoveTarget.Center - Transform.GetLocation()).GetSafeNormal();
+
+			// Once we are close enough to our goal, create stand action
+			if (MoveTarget.DistanceToGoal <= MoveTarget.SlackRadius)
+			{
+				MoveTarget.CreateNewAction(EMassMovementAction::Stand, *GetWorld());
+				Velocity = FVector::Zero();
+			} 
+		}
+	});
+}
+
+void URTSFormationUpdate::Initialize(UObject& Owner)
+{
+	Super::Initialize(Owner);
+	SubscribeToSignal(FormationUpdated);
+
+	FormationSubsystem = UWorld::GetSubsystem<URTSFormationSubsystem>(Owner.GetWorld());
+}
+
+void URTSFormationUpdate::ConfigureQueries()
+{
+	EntityQuery.AddRequirement<FRTSFormationAgent>(EMassFragmentAccess::ReadOnly);
+	EntityQuery.AddRequirement<FMassMoveTargetFragment>(EMassFragmentAccess::ReadWrite);
+	EntityQuery.AddRequirement<FTransformFragment>(EMassFragmentAccess::ReadOnly);
+	EntityQuery.AddSharedRequirement<FRTSFormationSettings>(EMassFragmentAccess::ReadOnly);
+}
+
+void URTSFormationUpdate::SignalEntities(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context,
+	FMassSignalNameLookup& EntitySignals)
+{
+	// Query to calculate move target for entities based on unit index
+	EntityQuery.ParallelForEachEntityChunk(EntitySubsystem, Context, [this](FMassExecutionContext& Context)
+	{
+		TConstArrayView<FRTSFormationAgent> RTSFormationAgents = Context.GetFragmentView<FRTSFormationAgent>();
+		TArrayView<FMassMoveTargetFragment> MoveTargetFragments = Context.GetMutableFragmentView<FMassMoveTargetFragment>();
+		TConstArrayView<FTransformFragment> TransformFragments = Context.GetFragmentView<FTransformFragment>();
+		const FRTSFormationSettings& RTSFormationSettings = Context.GetSharedFragment<FRTSFormationSettings>();
+		
+		for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
+		{
+			const FRTSFormationAgent& RTSFormationAgent = RTSFormationAgents[EntityIndex];
+			FMassMoveTargetFragment& MoveTarget = MoveTargetFragments[EntityIndex];
+			const FTransform& Transform = TransformFragments[EntityIndex].GetTransform();
+
+			// Can be optimized by caching?
+			const int UnitIndex = FormationSubsystem->Units.Find(Context.GetEntity(EntityIndex));
+
+			// Convert UnitIndex to X/Y coords
+			const int w = UnitIndex / RTSFormationSettings.FormationLength;
+			const int l = UnitIndex % RTSFormationSettings.FormationLength;
+
+			// We want the formation to be 'centered' so we need to create an offset
+			const FVector CenterOffset((RTSFormationSettings.FormationLength/2) * RTSFormationSettings.BufferDistance, (FormationSubsystem->Units.Num()/RTSFormationSettings.FormationLength/2) * RTSFormationSettings.BufferDistance, 0.f);
+
+			// Create movement action
+			MoveTarget.CreateNewAction(EMassMovementAction::Move, *GetWorld());
+			MoveTarget.Center = FVector(w*RTSFormationSettings.BufferDistance-CenterOffset.Y,l*RTSFormationSettings.BufferDistance-CenterOffset.X,0.f);
+			MoveTarget.Forward = (Transform.GetLocation() - MoveTarget.Center).GetSafeNormal();
+			MoveTarget.DistanceToGoal = (Transform.GetLocation() - MoveTarget.Center).Length();
+			MoveTarget.SlackRadius = 10.f;
+			MoveTarget.IntentAtGoal = EMassMovementAction::Stand;
+		}
+	});
+}

--- a/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormationProcessors.h
+++ b/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormationProcessors.h
@@ -1,0 +1,58 @@
+﻿#pragma once
+#include "MassEntityQuery.h"
+#include "MassObserverProcessor.h"
+#include "MassProcessor.h"
+#include "MassSignalProcessorBase.h"
+#include "RTSFormationProcessors.generated.h"
+
+class URTSFormationSubsystem;
+const FName FormationUpdated = FName(TEXT("FormationUpdated"));
+
+// Observer that runs when a unit is spawned. Calculates square formation position based on unit count
+UCLASS()
+class RTSFORMATIONS_API URTSFormationInitializer : public UMassObserverProcessor
+{
+	GENERATED_BODY()
+
+	URTSFormationInitializer();
+	virtual void ConfigureQueries() override;
+	virtual void Initialize(UObject& Owner) override;
+	virtual void Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context) override;
+	virtual void Register() override;
+
+	FMassEntityQuery EntityQuery;
+
+	FMassEntityQuery MoveEntityQuery;
+
+	FMassEntityQuery DestroyQuery;
+
+	TObjectPtr<UMassSignalSubsystem> SignalSubsystem;
+	
+	TObjectPtr<URTSFormationSubsystem> FormationSubsystem;
+};
+
+// Simple movement processor to get agents from a to b
+UCLASS()
+class RTSFORMATIONS_API URTSAgentMovement : public UMassProcessor
+{
+	GENERATED_BODY()
+	
+	virtual void ConfigureQueries() override;
+	virtual void Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context) override;
+
+	FMassEntityQuery EntityQuery;
+
+	FMassEntityQuery FormationQuery;
+};
+
+UCLASS()
+class RTSFORMATIONS_API URTSFormationUpdate : public UMassSignalProcessorBase
+{
+	GENERATED_BODY()
+	
+	virtual void Initialize(UObject& Owner) override;
+	virtual void ConfigureQueries() override;
+	virtual void SignalEntities(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context, FMassSignalNameLookup& EntitySignals) override;
+
+	TObjectPtr<URTSFormationSubsystem> FormationSubsystem;
+};

--- a/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormationSubsystem.cpp
+++ b/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormationSubsystem.cpp
@@ -1,0 +1,18 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RTSFormationSubsystem.h"
+
+#include "MassAgentComponent.h"
+#include "MassEntitySubsystem.h"
+#include "MassSignalSubsystem.h"
+#include "RTSFormationProcessors.h"
+
+void URTSFormationSubsystem::DestroyEntity(UMassAgentComponent* Entity)
+{
+	UMassEntitySubsystem* EntitySubsystem = GetWorld()->GetSubsystem<UMassEntitySubsystem>();
+	EntitySubsystem->Defer().DestroyEntity(Entity->GetEntityHandle());
+	UE_LOG(LogTemp, Error, TEXT("Entity: %d"), Entity->GetEntityHandle().Index)
+	Units.Remove(Entity->GetEntityHandle());
+	GetWorld()->GetSubsystem<UMassSignalSubsystem>()->SignalEntities(FormationUpdated, Units);
+}

--- a/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormationSubsystem.cpp
+++ b/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormationSubsystem.cpp
@@ -12,7 +12,8 @@ void URTSFormationSubsystem::DestroyEntity(UMassAgentComponent* Entity)
 {
 	UMassEntitySubsystem* EntitySubsystem = GetWorld()->GetSubsystem<UMassEntitySubsystem>();
 	EntitySubsystem->Defer().DestroyEntity(Entity->GetEntityHandle());
-	UE_LOG(LogTemp, Error, TEXT("Entity: %d"), Entity->GetEntityHandle().Index)
+	
+	// My current observer implementation doesnt handle entity destruction properly, so the logic is performed here for the time
 	Units.Remove(Entity->GetEntityHandle());
 	GetWorld()->GetSubsystem<UMassSignalSubsystem>()->SignalEntities(FormationUpdated, Units);
 }

--- a/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormationSubsystem.h
+++ b/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormationSubsystem.h
@@ -1,0 +1,26 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Common/Misc/MSBPFunctionLibrary.h"
+#include "RTSFormationSubsystem.generated.h"
+
+class UMassAgentComponent;
+struct FMassEntityHandle;
+/**
+ * 
+ */
+UCLASS()
+class RTSFORMATIONS_API URTSFormationSubsystem : public UWorldSubsystem
+{
+	GENERATED_BODY()
+	
+public:
+	// Stores the num of units in the formation
+	UPROPERTY()
+	TArray<FMassEntityHandle> Units;
+
+	UFUNCTION(BlueprintCallable)
+	void DestroyEntity(UMassAgentComponent* Entity);
+};

--- a/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormations.cpp
+++ b/Plugins/RTSFormations/Source/RTSFormations/Private/RTSFormations.cpp
@@ -1,0 +1,20 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#include "RTSFormations.h"
+
+#define LOCTEXT_NAMESPACE "FRTSFormationsModule"
+
+void FRTSFormationsModule::StartupModule()
+{
+	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
+}
+
+void FRTSFormationsModule::ShutdownModule()
+{
+	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
+	// we call this function before unloading the module.
+}
+
+#undef LOCTEXT_NAMESPACE
+	
+IMPLEMENT_MODULE(FRTSFormationsModule, RTSFormations)

--- a/Plugins/RTSFormations/Source/RTSFormations/Public/RTSAgentTraits.h
+++ b/Plugins/RTSFormations/Source/RTSFormations/Public/RTSAgentTraits.h
@@ -1,0 +1,54 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MassEntityTraitBase.h"
+#include "MassEntityTypes.h"
+#include "MassObserverProcessor.h"
+#include "RTSAgentTraits.generated.h"
+
+// Store basic info about the unit
+USTRUCT()
+struct RTSFORMATIONS_API FRTSFormationAgent : public FMassFragment
+{
+	GENERATED_BODY()
+
+	// The index of the unit in the formation
+	int UnitIndex = 0;
+};
+
+UCLASS()
+class RTSFORMATIONS_API URTSFormationAgentTrait : public UMassEntityTraitBase
+{
+	GENERATED_BODY()
+	
+	virtual void BuildTemplate(FMassEntityTemplateBuildContext& BuildContext, UWorld& World) const override;
+};
+
+// Ensure that units are in formation
+UCLASS()
+class RTSFORMATIONS_API URTSFormationInitializer : public UMassObserverProcessor
+{
+	GENERATED_BODY()
+
+	URTSFormationInitializer();
+	virtual void ConfigureQueries() override;
+	virtual void Initialize(UObject& Owner) override;
+	virtual void Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context) override;
+
+	FMassEntityQuery EntityQuery;
+
+	FMassEntityQuery MoveEntityQuery;
+};
+
+UCLASS()
+class RTSFORMATIONS_API URTSAgentMovement : public UMassProcessor
+{
+	GENERATED_BODY()
+	
+	virtual void ConfigureQueries() override;
+	virtual void Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context) override;
+
+	FMassEntityQuery EntityQuery;
+};

--- a/Plugins/RTSFormations/Source/RTSFormations/Public/RTSAgentTraits.h
+++ b/Plugins/RTSFormations/Source/RTSFormations/Public/RTSAgentTraits.h
@@ -18,6 +18,25 @@ struct RTSFORMATIONS_API FRTSFormationAgent : public FMassFragment
 	int UnitIndex = 0;
 };
 
+USTRUCT()
+struct RTSFORMATIONS_API FRTSFormationSettings : public FMassSharedFragment
+{
+	GENERATED_BODY()
+
+	// Distance between each unit
+	UPROPERTY(EditAnywhere, Category = "Formation")
+	float BufferDistance = 100.f;
+
+	// Width ratio for formation
+	UPROPERTY(EditAnywhere, Category = "Formation")
+	int UnitRatioX = 1;
+
+	// Length ratio for formation
+	UPROPERTY(EditAnywhere, Category = "Formation")
+	int UnitRatioY = 1;
+};
+
+// Provides entity with FRTSFormationAgent fragment to enable formations
 UCLASS()
 class RTSFORMATIONS_API URTSFormationAgentTrait : public UMassEntityTraitBase
 {
@@ -26,7 +45,7 @@ class RTSFORMATIONS_API URTSFormationAgentTrait : public UMassEntityTraitBase
 	virtual void BuildTemplate(FMassEntityTemplateBuildContext& BuildContext, UWorld& World) const override;
 };
 
-// Ensure that units are in formation
+// Observer that runs when a unit is spawned. Calculates square formation position based on unit count
 UCLASS()
 class RTSFORMATIONS_API URTSFormationInitializer : public UMassObserverProcessor
 {
@@ -42,6 +61,7 @@ class RTSFORMATIONS_API URTSFormationInitializer : public UMassObserverProcessor
 	FMassEntityQuery MoveEntityQuery;
 };
 
+// Simple movement processor to get agents from a to b
 UCLASS()
 class RTSFORMATIONS_API URTSAgentMovement : public UMassProcessor
 {

--- a/Plugins/RTSFormations/Source/RTSFormations/Public/RTSAgentTraits.h
+++ b/Plugins/RTSFormations/Source/RTSFormations/Public/RTSAgentTraits.h
@@ -5,8 +5,9 @@
 #include "CoreMinimal.h"
 #include "MassEntityTraitBase.h"
 #include "MassEntityTypes.h"
-#include "MassObserverProcessor.h"
 #include "RTSAgentTraits.generated.h"
+
+class URTSFormationSubsystem;
 
 // Store basic info about the unit
 USTRUCT()
@@ -27,13 +28,9 @@ struct RTSFORMATIONS_API FRTSFormationSettings : public FMassSharedFragment
 	UPROPERTY(EditAnywhere, Category = "Formation")
 	float BufferDistance = 100.f;
 
-	// Width ratio for formation
+	// Unit width of formation
 	UPROPERTY(EditAnywhere, Category = "Formation")
-	int UnitRatioX = 1;
-
-	// Length ratio for formation
-	UPROPERTY(EditAnywhere, Category = "Formation")
-	int UnitRatioY = 1;
+	int FormationLength = 1;
 };
 
 // Provides entity with FRTSFormationAgent fragment to enable formations
@@ -43,32 +40,11 @@ class RTSFORMATIONS_API URTSFormationAgentTrait : public UMassEntityTraitBase
 	GENERATED_BODY()
 	
 	virtual void BuildTemplate(FMassEntityTemplateBuildContext& BuildContext, UWorld& World) const override;
+
+	UPROPERTY(EditAnywhere)
+	FRTSFormationSettings FormationSettings;
 };
 
-// Observer that runs when a unit is spawned. Calculates square formation position based on unit count
-UCLASS()
-class RTSFORMATIONS_API URTSFormationInitializer : public UMassObserverProcessor
-{
-	GENERATED_BODY()
-
-	URTSFormationInitializer();
-	virtual void ConfigureQueries() override;
-	virtual void Initialize(UObject& Owner) override;
-	virtual void Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context) override;
-
-	FMassEntityQuery EntityQuery;
-
-	FMassEntityQuery MoveEntityQuery;
-};
-
-// Simple movement processor to get agents from a to b
-UCLASS()
-class RTSFORMATIONS_API URTSAgentMovement : public UMassProcessor
-{
-	GENERATED_BODY()
-	
-	virtual void ConfigureQueries() override;
-	virtual void Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context) override;
-
-	FMassEntityQuery EntityQuery;
-};
+//@todo create destroyer observer processor to handle updating units
+//@todo create another processor to handle when units need to be updated (using bUpdateUnitPosition in SharedFragment)
+//@todo I definitely went overboard in terms of complexity, this example should really just be straightforward to read and have performance second i think

--- a/Plugins/RTSFormations/Source/RTSFormations/Public/RTSFormations.h
+++ b/Plugins/RTSFormations/Source/RTSFormations/Public/RTSFormations.h
@@ -1,0 +1,15 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
+
+class FRTSFormationsModule : public IModuleInterface
+{
+public:
+
+	/** IModuleInterface implementation */
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};

--- a/Plugins/RTSFormations/Source/RTSFormations/RTSFormations.Build.cs
+++ b/Plugins/RTSFormations/Source/RTSFormations/RTSFormations.Build.cs
@@ -25,7 +25,7 @@ public class RTSFormations : ModuleRules
 		PublicDependencyModuleNames.AddRange(
 			new string[]
 			{
-				"Core", "MassSpawner", "MassEntity", "MassCommon", "StructUtils"
+				"Core", "MassSpawner", "MassEntity", "MassCommon", "StructUtils", "MassSignals", "MassMovement"
 				// ... add other public dependencies that you statically link with here ...
 			}
 			);
@@ -37,7 +37,7 @@ public class RTSFormations : ModuleRules
 				"CoreUObject",
 				"Engine",
 				"Slate",
-				"SlateCore", "MassNavigation",
+				"SlateCore", "MassNavigation", "MassSample", "MassActors",
 				// ... add private dependencies that you statically link with here ...	
 			}
 			);

--- a/Plugins/RTSFormations/Source/RTSFormations/RTSFormations.Build.cs
+++ b/Plugins/RTSFormations/Source/RTSFormations/RTSFormations.Build.cs
@@ -25,7 +25,7 @@ public class RTSFormations : ModuleRules
 		PublicDependencyModuleNames.AddRange(
 			new string[]
 			{
-				"Core", "MassSpawner", "MassEntity", "MassCommon"
+				"Core", "MassSpawner", "MassEntity", "MassCommon", "StructUtils"
 				// ... add other public dependencies that you statically link with here ...
 			}
 			);

--- a/Plugins/RTSFormations/Source/RTSFormations/RTSFormations.Build.cs
+++ b/Plugins/RTSFormations/Source/RTSFormations/RTSFormations.Build.cs
@@ -1,0 +1,53 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+using UnrealBuildTool;
+
+public class RTSFormations : ModuleRules
+{
+	public RTSFormations(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+		
+		PublicIncludePaths.AddRange(
+			new string[] {
+				// ... add public include paths required here ...
+			}
+			);
+				
+		
+		PrivateIncludePaths.AddRange(
+			new string[] {
+				// ... add other private include paths required here ...
+			}
+			);
+			
+		
+		PublicDependencyModuleNames.AddRange(
+			new string[]
+			{
+				"Core", "MassSpawner", "MassEntity", "MassCommon"
+				// ... add other public dependencies that you statically link with here ...
+			}
+			);
+			
+		
+		PrivateDependencyModuleNames.AddRange(
+			new string[]
+			{
+				"CoreUObject",
+				"Engine",
+				"Slate",
+				"SlateCore", "MassNavigation",
+				// ... add private dependencies that you statically link with here ...	
+			}
+			);
+		
+		
+		DynamicallyLoadedModuleNames.AddRange(
+			new string[]
+			{
+				// ... add any modules that your module loads dynamically here ...
+			}
+			);
+	}
+}


### PR DESCRIPTION
Early example of simple unit formations. There is still a lot of cleanup to be done but the core functionality is there.

- 'Rectangle' formation by specifying a `FormationLength` in the `RTSFormationTrait`
- Spawning and shooting entities will appropriately shift the formation to fill any gaps
- Encapsulated in a plugin (though it does depend on some things in the project)


![image](https://user-images.githubusercontent.com/1747157/178162688-83f6aef6-4331-46f7-b643-74eba72c35ce.png)

https://user-images.githubusercontent.com/1747157/178162858-c0dace7c-4474-4719-8cee-82d1a091d3d5.mp4


https://user-images.githubusercontent.com/1747157/178162889-841d7e2e-a90d-4d9f-816f-83684432b1e7.mp4


https://user-images.githubusercontent.com/1747157/178162918-2471bb9d-351c-4b40-bf5b-9be2541f01a0.mp4


Known issues
- When spawning a large amount of entities (>100) actor visualization appears to stop functioning. May be unrelated to my code.
- Performance was not a priority so some things can definitely be optimized
- `URTSFormationInitializer` does not properly handle entity destruction. It is temporarily handled in the subsystem.
- A few processors are bundled together. For readability, I might separate them in the future.
- Unit movement is not implemented but should theoretically be straightforward.
- When units are destroyed, the entity index is sometimes not properly handled.