### PR TITLE
ISM Custom Data Query Optimization

### DIFF
--- a/Plugins/MassCommunitySample/Source/MassCommunitySample/Representation/Processors/ISMPerInstanceDataProcessors.cpp
+++ b/Plugins/MassCommunitySample/Source/MassCommunitySample/Representation/Processors/ISMPerInstanceDataProcessors.cpp
@@ -16,6 +16,8 @@ void UismPerInstanceDataUpdater::ConfigureQueries()
 	EntityQuery.AddRequirement<FMassRepresentationFragment>(EMassFragmentAccess::ReadWrite);
 	EntityQuery.AddRequirement<FMassRepresentationLODFragment>(EMassFragmentAccess::ReadOnly);
 	EntityQuery.AddSharedRequirement<FMassRepresentationSubsystemSharedFragment>(EMassFragmentAccess::ReadWrite);
+	EntityQuery.AddChunkRequirement<FMassVisualizationChunkFragment>(EMassFragmentAccess::ReadOnly);
+    EntityQuery.SetChunkFilter(&FMassVisualizationChunkFragment::AreAnyEntitiesVisibleInChunk);
 }
 
 void UismPerInstanceDataUpdater::Execute(UMassEntitySubsystem& EntitySubsystem, FMassExecutionContext& Context)

--- a/Plugins/MassCommunitySample/Source/MassCommunitySample/Representation/Processors/ISMPerInstanceDataProcessors.cpp
+++ b/Plugins/MassCommunitySample/Source/MassCommunitySample/Representation/Processors/ISMPerInstanceDataProcessors.cpp
@@ -44,7 +44,7 @@ void UismPerInstanceDataUpdater::Execute(UMassEntitySubsystem& EntitySubsystem, 
 
 
 				// This can accept any struct that the size of n floats. It seems to be required to be called every frame we want to change it
-				ISMInfo.AddBatchedCustomData(RenderData.Data, RepresentationLOD.LODSignificance);
+				ISMInfo.AddBatchedCustomData(RenderData.Data, RepresentationLOD.LODSignificance, Representation.PrevLODSignificance);
 			}
 		}
 	});


### PR DESCRIPTION
Simple PR which I originally thought to fix some rare crashing with ISM Custom Data but I believe it was fixed with 5.0.3.

Really just a simple query suggestion/optimization to prevent sending updates to ISMs that aren't being rendered.
It also just quickly includes the PreviousLODSignificance when sending the batched custom data. This allows the batched data to also be sent to the last LOD range (My guess for a better transition).


