### PR TITLE
Fix crash in Linux by initializing VariableName with 0 for consistent behavior across platforms

### DIFF
--- a/Plugins/MassCommunitySample/Source/MassCommunitySample/ProjectileSim/Processors/MSProjectileSimProcessors.cpp
+++ b/Plugins/MassCommunitySample/Source/MassCommunitySample/ProjectileSim/Processors/MSProjectileSimProcessors.cpp
@@ -197,7 +197,7 @@ void UMSProjectileOctreeQueryProcessors::Execute(FMassEntityManager& EntityManag
 	FMSOctree2& MSOctree2 = MSSubsystem->Octree2;
 
 	TQueue<FMassEntityHandle,EQueueMode::Mpsc> EntitiesThatWereHit;
-	std::atomic<int32> EntitiesThatWereHitNum;
+	std::atomic<int32> EntitiesThatWereHitNum(0);
 
 	auto World = EntityManager.GetWorld();
 


### PR DESCRIPTION
This pull request addresses a crucial issue by properly initializing the variable with a value of 0. In C++, the initialization of a std::atomic<int32> variable involves using the constructor to provide an initial value. By ensuring the initialization of the variable, we ensure consistent behavior across different platforms, such as Windows and Linux. This fix is essential as it resolves a crash that was occurring specifically in Linux.