### PR TITLE
Update per-query parallelism section

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,7 +959,18 @@ Out of the box Mass can spread out work to threads in two different ways:
 <!--FIXMEFUNK - we really need to figure out which ini this goes in...-->
 - Per-Processor threading based on the processor dependency graph by setting the console variable `mass.FullyParallel 1`
 
-- Per-query parrallel for calls that spread the job of one query over multiple threads by using the command argument `ParallelMassQueries=1` for the given Unreal process. This is currently used nowhere in the Mass modules or sample and currently it seems to break when deferring commands from it multiple times a frame.
+- Per-query parallelism spreads the job of one query over multiple threads using a `ParallelFor`. This is available by using `Query.ParallelForEachEntityChunk` in place of `Query.ForEachEntityChunk`.
+```c++
+MyQuery.ParallelForEachEntityChunk(EntityManager, Context, [](FMassExecutionContext& Context)
+{
+	//Loop over every entity in the current chunk and do stuff!
+	for (int32 EntityIndex = 0; EntityIndex < Context.GetNumEntities(); ++EntityIndex)
+	{
+		// ...
+	}
+}, FMassEntityQuery::ForceParallelExecution);
+```
+Note that ParallelForEachEntityChunk will create a dedicated command buffer for each job by default.
 
 
 <a name="mass-cm"></a>


### PR DESCRIPTION
Per-query parallelism is now supported. See: 
https://github.com/EpicGames/UnrealEngine/commit/b04a6ec56a385ed06a5cf175ef7db7c468cd2e5c